### PR TITLE
feat: add a bench client; feat: bench against ntex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-oneshot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec7c75bcbcb0139e9177f30692fd617405ca4e0c27802e128d53171f7042e2c"
+dependencies = [
+ "futures-micro",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +305,14 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "benchmarks"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "tokio",
+]
 
 [[package]]
 name = "bitflags"
@@ -329,6 +357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +376,12 @@ checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
  "bytes",
 ]
+
+[[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
@@ -372,6 +412,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "clicky-ntex"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "futures-util",
+ "log",
+ "ntex",
+ "ntex-cors",
+ "ntex-tokio",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +448,22 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -462,6 +539,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "firestorm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +578,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,10 +603,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
@@ -510,6 +659,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "futures-micro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b460264b3593d68b16a7bc35f7bc226ddfebdf9a1c8db1ed95d5cc6b7168c826"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -525,17 +683,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -605,6 +782,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +809,43 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "idna"
@@ -642,6 +867,21 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itoa"
@@ -774,12 +1014,214 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
+
+[[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ntex"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edea96a83d6b024e3b6a3e198045004342b940b52133052b3bc78968cc08dc11"
+dependencies = [
+ "async-channel",
+ "async-oneshot",
+ "base64",
+ "bitflags",
+ "encoding_rs",
+ "h2",
+ "http",
+ "httparse",
+ "httpdate",
+ "log",
+ "mime",
+ "nanorand",
+ "ntex-bytes",
+ "ntex-codec",
+ "ntex-io",
+ "ntex-macros",
+ "ntex-router",
+ "ntex-rt",
+ "ntex-service",
+ "ntex-tls",
+ "ntex-tokio",
+ "ntex-util",
+ "num_cpus",
+ "percent-encoding",
+ "pin-project-lite",
+ "polling",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha-1",
+ "socket2",
+ "thiserror",
+]
+
+[[package]]
+name = "ntex-bytes"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ca93c0a64eb4f051967f83b4efa268097dddb751f2e777c52a97a7baa7b0eb"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "serde",
+]
+
+[[package]]
+name = "ntex-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a7e111d946bb915d712df496728ca2a120b1b5643f66c580f13023bce46fda"
+dependencies = [
+ "ntex-bytes",
+]
+
+[[package]]
+name = "ntex-cors"
+version = "0.2.0"
+source = "git+https://github.com/ntex-rs/ntex-extras#b22435317ecae4b5dfb94e97a56500a4d17aa99b"
+dependencies = [
+ "derive_more",
+ "futures",
+ "ntex",
+]
+
+[[package]]
+name = "ntex-io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e474d6c9c784982c484b7aa5a40718f2af8623e681e1823b0818d4e9beff2e"
+dependencies = [
+ "bitflags",
+ "log",
+ "ntex-bytes",
+ "ntex-codec",
+ "ntex-service",
+ "ntex-util",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "ntex-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a359f2a10c712b0446675070c22b1437d57a7cf08139f6a229e1e80817ed84"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ntex-router"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67631bca69fc552ba9615b36637eee827fbf4752eec4c7bc10f7135695cc1b9e"
+dependencies = [
+ "http",
+ "log",
+ "ntex-bytes",
+ "regex",
+ "serde",
+]
+
+[[package]]
+name = "ntex-rt"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a6e04d92fefeefc45ca760fd633516fcea6cfe2288b6d4b00a6c8994be1410"
+dependencies = [
+ "async-channel",
+ "async-oneshot",
+ "futures-core",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "ntex-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9d5abeedc0d52dd936f97bc2df476fb2fcbaf152c45204f12d24eb218565b"
+dependencies = [
+ "pin-project-lite",
+]
+
+[[package]]
+name = "ntex-tls"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00841754ccce812cb573f46090a2633698cce401f1a4e6cd196a07d3dacd934b"
+dependencies = [
+ "ntex-bytes",
+ "ntex-io",
+ "ntex-service",
+ "ntex-util",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "ntex-tokio"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cf47dded203fdba51a7a649d9f54648431e73e7fc6b426f55f3e697229fe38"
+dependencies = [
+ "log",
+ "ntex-bytes",
+ "ntex-io",
+ "ntex-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "ntex-util"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca174ec984a4cdd1f216b8ccbdf9bf0924a75f573e275c1d3371bc45ccaecac4"
+dependencies = [
+ "bitflags",
+ "futures-core",
+ "futures-sink",
+ "futures-timer",
+ "fxhash",
+ "log",
+ "ntex-rt",
+ "ntex-service",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -806,6 +1248,39 @@ name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -853,6 +1328,25 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "polling"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -935,6 +1429,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1542,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1575,20 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -1087,12 +1673,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1138,12 +1758,35 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "num_cpus",
  "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1170,6 +1813,12 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -1203,6 +1852,12 @@ checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
@@ -1250,10 +1905,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1290,6 +1961,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1348,6 +2031,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1423,6 +2115,15 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,6 @@ name = "clicky"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 actix-cors = "0.6.1"
 actix-http = "3.0.4"
@@ -13,3 +11,11 @@ anyhow = "1.0.56"
 env_logger = "0.9.0"
 futures-util = "0.3.21"
 log = "0.4.16"
+
+[workspace]
+members = [".", "benchmarks", "clicky-ntex"]
+
+[profile.release]
+lto = true
+opt-level = 3
+codegen-units = 1

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "benchmarks"
+version = "0.1.0"
+edition = "2021"
+
+
+[[bin]]
+name = "client"
+path = "src/client.rs"
+
+[[bin]]
+name = "client-binary"
+path = "src/client-binary.rs"
+
+
+[dependencies]
+tokio = { version = "1.17.0", features = ["full"] }
+reqwest = "0.11.10"

--- a/benchmarks/src/client-binary.rs
+++ b/benchmarks/src/client-binary.rs
@@ -1,0 +1,49 @@
+#![feature(core_intrinsics)]
+extern crate benchmarks;
+
+use std::time::Duration;
+
+use reqwest::{Body, Method, Request, Url};
+
+#[tokio::main]
+async fn main() {
+  let args = std::env::args().skip(1).take(2).collect::<Vec<_>>();
+  if args.len() != 2 {
+    panic!("Must provide [METHOD] [URL]");
+  }
+
+  let method = args[0]
+    .parse::<Method>()
+    .expect("Expected a valid HTTP method");
+  let url = args[1].parse::<Url>().expect("Expected a valid URL");
+
+  eprintln!("START {method} {url}");
+
+  let mut request = Request::new(method, url);
+  let bytes = Box::leak(Box::new(500u16.to_le_bytes()));
+  *request.body_mut() = Some(Body::from(bytes as &[u8]));
+  let headers = reqwest::header::HeaderMap::new();
+
+  let client = &*Box::leak(Box::new(
+    reqwest::Client::builder()
+      .default_headers(headers)
+      .build()
+      .unwrap(),
+  ));
+  let request = &*Box::leak(Box::new(
+    request.try_clone().expect("Request must be clonable"),
+  ));
+
+  const N_CPUS: usize = 12;
+  benchmarks::run!(
+    C = 1024 * N_CPUS,
+    report_freq = Duration::from_millis(1000),
+    send = client
+      .execute(unsafe { request.try_clone().unwrap_unchecked() })
+      .await
+      .map(|res| res.status().as_u16())
+      .unwrap_or(500)
+      < 400,
+    timeout = Duration::from_secs(60)
+  );
+}

--- a/benchmarks/src/client.rs
+++ b/benchmarks/src/client.rs
@@ -1,0 +1,48 @@
+#![feature(core_intrinsics)]
+extern crate benchmarks;
+
+use std::time::Duration;
+
+use reqwest::{Body, Method, Request, Url};
+
+#[tokio::main]
+async fn main() {
+  let args = std::env::args().skip(1).take(2).collect::<Vec<_>>();
+  if args.len() != 2 {
+    panic!("Must provide [METHOD] [URL]");
+  }
+
+  let method = args[0]
+    .parse::<Method>()
+    .expect("Expected a valid HTTP method");
+  let url = args[1].parse::<Url>().expect("Expected a valid URL");
+
+  eprintln!("START {method} {url}");
+
+  let mut request = Request::new(method, url);
+  *request.body_mut() = Some(Body::from(b"500" as &[u8]));
+  let headers = reqwest::header::HeaderMap::new();
+
+  let client = &*Box::leak(Box::new(
+    reqwest::Client::builder()
+      .default_headers(headers)
+      .build()
+      .unwrap(),
+  ));
+  let request = &*Box::leak(Box::new(
+    request.try_clone().expect("Request must be clonable"),
+  ));
+
+  const N_CPUS: usize = 12;
+  benchmarks::run!(
+    C = 1024 * N_CPUS,
+    report_freq = Duration::from_millis(1000),
+    send = client
+      .execute(unsafe { request.try_clone().unwrap_unchecked() })
+      .await
+      .map(|res| res.status().as_u16())
+      .unwrap_or(500)
+      < 400,
+    timeout = Duration::from_secs(60)
+  );
+}

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,0 +1,100 @@
+#![feature(core_intrinsics)]
+use std::time::Duration;
+
+pub use std::intrinsics;
+pub use tokio::sync::Semaphore;
+
+#[macro_export]
+macro_rules! run {
+    (C = $concurrency:expr, report_freq = $d:expr, send = $send:expr) => {
+        $crate::run!(
+            C = $concurrency,
+            report_freq = $d,
+            send = $send,
+            __timeout = loop
+        )
+    };
+    (C = $concurrency:expr, report_freq = $d:expr, send = $send:expr, timeout = $timeout_duration:expr) => {
+        let start = std::time::Instant::now();
+        let timeout = $timeout_duration;
+        $crate::run!(
+            C = $concurrency,
+            report_freq = $d,
+            send = $send,
+            __timeout = while start.elapsed() < timeout
+        )
+    };
+    (C = $concurrency:expr, report_freq = $d:expr, send = $send:expr, __timeout = $($timeout:tt)*) => {{
+        const CONCURRENCY: usize = $concurrency;
+        static SEM: $crate::Semaphore = $crate::Semaphore::const_new(CONCURRENCY);
+        static COUNTER: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+        let report_frequency: core::time::Duration = $d;
+
+        let mut prev_count = 0;
+        let mut time = std::time::Instant::now();
+        let total_time = std::time::Instant::now();
+
+        $($timeout)* {
+            let permit = SEM.acquire().await.unwrap();
+            tokio::spawn({
+                async move {
+                    let result: bool = $send;
+                    std::mem::drop(permit);
+                    if std::intrinsics::likely(result) {
+                        COUNTER.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                    } else {
+                        return;
+                    }
+                }
+            });
+
+            if time.elapsed() > report_frequency {
+                let count = COUNTER.load(core::sync::atomic::Ordering::Relaxed);
+                eprintln!(
+                    "Total requests: {}. Requests in the last {}ms: {} [{:.3}s total] [{} avg. RPS]",
+                    count,
+                    time.elapsed().as_millis(),
+                    count - prev_count,
+                    total_time.elapsed().as_secs_f64(),
+                    count as f64 / total_time.elapsed().as_secs_f64()
+                );
+                prev_count = count;
+                time = std::time::Instant::now();
+            }
+        }
+        #[allow(unreachable_code)]
+        COUNTER.load(core::sync::atomic::Ordering::Relaxed)
+    }};
+}
+
+#[inline]
+pub async fn http_client(
+  request: reqwest::Request,
+  headers: reqwest::header::HeaderMap,
+) -> Result<usize, Box<dyn std::error::Error + 'static>> {
+  let client = &*Box::leak(Box::new(
+    reqwest::Client::builder()
+      .default_headers(headers)
+      .build()
+      .unwrap(),
+  ));
+  let request = &*Box::leak(Box::new(
+    request.try_clone().expect("Request must be clonable"),
+  ));
+  #[allow(unused)]
+  let res = run!(
+    C = 1024,
+    report_freq = Duration::from_millis(1000),
+    send = client
+      .execute(unsafe { request.try_clone().unwrap_unchecked() })
+      .await
+      .map(|res| res.status().as_u16())
+      .unwrap_or(500)
+      < 400
+  );
+  unsafe {
+    Box::from_raw(&mut *request);
+    Box::from_raw(&mut *client);
+  }
+  Ok(res)
+}

--- a/clicky-ntex/Cargo.toml
+++ b/clicky-ntex/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "clicky-ntex"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "clicky-ntex"
+path = "src/main.rs"
+
+[dependencies]
+ntex = { version = "0.5.14", features = ["tokio"] }
+ntex-cors = { git = "https://github.com/ntex-rs/ntex-extras" }
+futures-util = "0.3.21"
+ntex-tokio = "0.1.3"
+env_logger = "0.9.0"
+log = "0.4.16"

--- a/clicky-ntex/src/error.rs
+++ b/clicky-ntex/src/error.rs
@@ -1,0 +1,62 @@
+use ntex::{
+  http::StatusCode,
+  web::{HttpRequest, HttpResponse, WebResponseError},
+};
+
+#[derive(Debug, Clone)]
+pub struct Error {
+  code: StatusCode,
+}
+
+impl std::fmt::Display for Error {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.code)
+  }
+}
+
+impl std::error::Error for Error {}
+
+impl WebResponseError for Error {
+  fn status_code(&self) -> StatusCode {
+    self.code
+  }
+
+  fn error_response(&self, _: &HttpRequest) -> HttpResponse {
+    HttpResponse::build(self.code).finish()
+  }
+}
+
+pub trait Failure<T> {
+  fn failed(self, code: StatusCode) -> std::result::Result<T, Error>;
+  fn internal(self) -> std::result::Result<T, Error>;
+}
+
+impl<T, E: std::fmt::Debug> Failure<T> for std::result::Result<T, E> {
+  fn failed(self, code: StatusCode) -> std::result::Result<T, Error> {
+    self.map_err(|e| {
+      log::error!("Discarded error: {:?}", e);
+      Error { code }
+    })
+  }
+
+  fn internal(self) -> std::result::Result<T, Error> {
+    self.map_err(|e| {
+      log::error!("Discarded error: {:?}", e);
+      Error {
+        code: StatusCode::INTERNAL_SERVER_ERROR,
+      }
+    })
+  }
+}
+
+impl<T> Failure<T> for std::option::Option<T> {
+  fn failed(self, code: StatusCode) -> std::result::Result<T, Error> {
+    self.ok_or(Error { code })
+  }
+
+  fn internal(self) -> std::result::Result<T, Error> {
+    self.ok_or(Error {
+      code: StatusCode::INTERNAL_SERVER_ERROR,
+    })
+  }
+}

--- a/clicky-ntex/src/main.rs
+++ b/clicky-ntex/src/main.rs
@@ -1,0 +1,105 @@
+mod error;
+
+use error::{Error, Failure};
+use futures_util::StreamExt;
+use ntex::{
+  http::{KeepAlive, StatusCode},
+  util::Bytes,
+  web::{
+    self,
+    types::{Payload, State},
+    App, HttpResponse, HttpServer,
+  },
+};
+use ntex_cors::Cors;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Atomic counter
+#[derive(Default)]
+struct Count(AtomicU64);
+impl Count {
+  /// Returns the current value
+  fn get(&self) -> u64 {
+    self.0.load(Ordering::SeqCst)
+  }
+
+  /// Adds `value` to `self`, returning the previous value
+  fn add(&self, value: u64) -> u64 {
+    self.0.fetch_add(value, Ordering::SeqCst)
+  }
+}
+
+async fn read_payload_static<const SIZE: usize>(
+  mut payload: ntex::web::types::Payload,
+) -> Result<Option<([u8; SIZE], usize)>, Error> {
+  let mut buf = [0u8; SIZE];
+  let mut read_bytes = 0;
+  while let Some(data) = payload.next().await {
+    let data = data.failed(StatusCode::BAD_REQUEST)?;
+    if data.is_empty() || data.len() > buf.len() - read_bytes {
+      return Ok(None);
+    }
+    buf[read_bytes..data.len()].copy_from_slice(&data);
+    read_bytes += data.len();
+  }
+  Ok(Some((buf, read_bytes)))
+}
+
+#[web::post("/")]
+async fn submit(body: Payload, count: State<Count>) -> Result<HttpResponse, Error> {
+  // NOTE: transmute vs parse doesn't make a difference
+
+  // let (raw, len) = read_payload_static::<2>(body)
+  //   .await
+  //   .internal()
+  //   .and_then(|i| i.failed(StatusCode::BAD_REQUEST))?;
+  // let value = u16::from_be_bytes(raw);
+
+  let (raw, len) = read_payload_static::<3>(body)
+    .await
+    .internal()
+    .and_then(|i| i.failed(StatusCode::BAD_REQUEST))?;
+
+  let value = std::str::from_utf8(&raw[0..len])
+    .failed(StatusCode::BAD_REQUEST)?
+    .parse::<u16>()
+    .failed(StatusCode::BAD_REQUEST)? as u64;
+
+  if value > 500 {
+    return Ok(HttpResponse::BadRequest().finish());
+  }
+
+  let old_count = count.get_ref().add(value as u64);
+  let new_count = old_count + value as u64;
+
+  // NOTE: Bytes doesn't allocate if the payload is <=30 bytes
+  Ok(HttpResponse::Ok().body(Bytes::copy_from_slice(&new_count.to_le_bytes())))
+}
+
+#[web::get("/")]
+async fn sync(count: State<Count>) -> HttpResponse {
+  let count = count.get_ref().get();
+  HttpResponse::Ok().body(format!("{count}"))
+}
+
+#[ntex::main]
+async fn main() -> std::io::Result<()> {
+  let addr = std::env::var("SERVER_ADDRESS").unwrap_or_else(|_| "127.0.0.1:8080".into());
+  let count = State::new(Count::default());
+  HttpServer::new(move || {
+    App::new()
+      .app_state(State::clone(&count))
+      .wrap(
+        Cors::new()
+          .allowed_methods(vec!["GET", "POST"])
+          .max_age(3600)
+          .finish(),
+      )
+      .service((sync, submit))
+  })
+  .backlog(2048)
+  .keep_alive(KeepAlive::Os)
+  .bind(&addr)?
+  .run()
+  .await
+}


### PR DESCRIPTION
## Environment
| Param         | Value                        |
|---------------|------------------------------|
| CPU           | Ryzen 5 3600 (12) @ 3.600GHz |
| RAM           | 64GB                         |
| Kernel        | `5.4.0`                      |
| Soft FD limit | `1048576`                    |
| Hard FD limit | `1048576`                    |
| Client threads | `12` |
| Bench time | 60s | 

## Results
NOTE: after more digging, I've discovered ntex spawns a thread both per physical and virtual  core, while actix spawns a thread only per physical core. This might explain the performance difference. Also, ntex threads consume the same amount of CPU consistently (around 25% per core), while actix threads jump from 15 to ~40avg to 60. Actix seems to take more time to deallocate memory than ntex, probably because ntex uses pools to allocate temporaries rather than the system allocator. 


| Configuration                                                     | RPS       | Standard Deviation |
|-------------------------------------------------------------------|-----------|--------------------|
| Baseline                                                          | `43,904`  | `7,729.05`         |
| Baseline, no logging                                              | `219,502` | `10,962.64`        |
| Global counter, no logging                                        | `220,135` | `8,756.91`         |
| Global counter, no logging, `KeepAlive::Os`                       | `231,202` | `5,237.95`         |
| Global counter, no logging, `KeepAlive::Os`, `snmalloc`           | `230,914` | `6,937.38`         |
| Ntex, no logging, `KeepAlive::Os`                                 | `224,109` | `3,415.54`         |
| Ntex, no logging, `KeepAlive::Os`, no allocations                 | `226,791` | `1,854.91`         |
| Ntex, no logging, `KeepAlive::Os`, no allocations, binary payload | `226,093` | `2,407.74`         |

## Preprocessing Code
```py
#! python -m pip install requests pandas
import pandas as pd
import requests

urls = {
    "baseline": "https://haste.zneix.eu/raw/ucuqyrohab.apache",
    "no-logging": "https://haste.zneix.eu/raw/vobojasegy.apache",
    "global,no-logging": "https://haste.zneix.eu/raw/zibexafuko.apache",
    "global,no-logging,backlog-1024,keepalive-os": "https://haste.zneix.eu/raw/enaxusiguk.apache",
    "global,no-logging,backlog-1024,keepalive-os,snmalloc": "https://haste.zneix.eu/raw/medibijyky.apache",
    "ntex,no-logging,backlog-1024,keepalive-os": "https://haste.zneix.eu/raw/reniwanawy.apache",
    "ntex,no-logging,backlog-1024,keepalive-os,no-allocations": "https://haste.zneix.eu/raw/hamosaceba.apache",
    "ntex,no-logging,backlog-1024,keepalive-os,no-allocations,binary-payload": "https://haste.zneix.eu/raw/itamalihoh.apache",
}

for url in urls:
    urls[url] = requests.get(urls[url]).text.strip().split("\n")[1:]

for url in urls:
    readings = []

    # skip the first `warmup` seconds
    warmup = 3
    for line in urls[url][warmup:]:
        before, after = line.split("ms:")
        time = before.rsplit(maxsplit=1)[-1].strip()
        requests = after.split()[0].strip()

        readings.append((int(time), int(requests)))

    df = pd.DataFrame(readings, columns=("ms", "requests"))
    df["rps"] = df["requests"] / df["ms"] * 1000

    rps = df["rps"].mean()
    stddev = df["rps"].std()
    print(f"|{url}|`{int(rps):,}`|`{stddev:,.2f}`|")

```